### PR TITLE
can't get proper value from application env

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}. %, fail_on_warning]}.
 
-{require_otp_vsn, "R14"}.
+{require_otp_vsn, "R15"}.
 
 {deps_dir, ["deps"]}.
 

--- a/src/bigwig.app.src
+++ b/src/bigwig.app.src
@@ -8,5 +8,5 @@
                   stdlib
                  ]},
   {mod, { bigwig_app, []}},
-  {env, []}
+  {env, [{port, 28989}]}
  ]}.

--- a/src/bigwig_http.erl
+++ b/src/bigwig_http.erl
@@ -39,7 +39,7 @@ dispatch_rules() ->
 confval(Key, Default) ->
     case application:get_env(Key) of
         undefined -> Default;
-        Val       -> Val
+        {ok, Val} -> Val
     end.
 
 init([]) ->

--- a/src/bigwig_http.erl
+++ b/src/bigwig_http.erl
@@ -44,7 +44,8 @@ confval(Key, Default) ->
 
 init([]) ->
     Port            = confval(port, 40829),
-    Ip              = confval(ip, "127.0.0.1"),
+	{ok, Hostname} 	= inet:gethostname(),
+    Ip              = confval(ip, Hostname),
     NumAcceptors    = confval(num_acceptors, 16),
 
     IpStr = case is_list(Ip) of true -> Ip; false -> inet_parse:ntoa(Ip) end,


### PR DESCRIPTION
The function application:get_env return  " undefined | {ok, term()} "

When I setting application env for example listening port or something,
it cause crash like below.

ERROR: "Bigwig listening on http://~s:~B/~n" - ["127.0.0.1",
                                                                         {ok,
                                                                          20829}]

=CRASH REPORT==== 13-Apr-2012::08:49:18 ===
  crasher:
    initial call: supervisor:cowboy_acceptors_sup/1
    pid: <0.75.0>
    registered_name: []
    exception exit: {function_clause,
                        [{inet_tcp,getserv,
                             [{ok,20829}],
                             [{file,"inet_tcp.erl"},{line,35}]},
                         {gen_tcp,listen,2,[{file,"gen_tcp.erl"},{line,182}]},
                         {cowboy_acceptors_sup,init,1,
                             [{file,"src/cowboy_acceptors_sup.erl"},
                              {line,42}]},
                         {supervisor,init,1,
                             [{file,"supervisor.erl"},{line,233}]},
                         {gen_server,init_it,6,
                             [{file,"gen_server.erl"},{line,304}]},
                         {proc_lib,init_p_do_apply,3,
                             [{file,"proc_lib.erl"},{line,227}]}]}
      in function  gen_server:init_it/6 (gen_server.erl, line 328)
    ancestors: [<0.72.0>,cowboy_sup,<0.58.0>]
    messages: []
    links: [<0.72.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 987
    stack_size: 24
    reductions: 171
  neighbours:

Please consider this pull request.
Thank you for reading.
