### PR TITLE
can't get proper value from application env

### DIFF
--- a/src/bigwig_http.erl
+++ b/src/bigwig_http.erl
@@ -39,7 +39,7 @@ dispatch_rules() ->
 confval(Key, Default) ->
     case application:get_env(Key) of
         undefined -> Default;
-        Val       -> Val
+        {ok, Val} -> Val
     end.
 
 init([]) ->


### PR DESCRIPTION
Reopen pull request. (pick valid commit only)

The function application:get_env return " undefined | {ok, term()} "

When I setting application env for example listening port or something,
it cause crash like below.

ERROR: "Bigwig listening on http://~s:~B/~n" - ["127.0.0.1",
{ok,
20829}]

=CRASH REPORT==== 13-Apr-2012::08:49:18 ===
crasher:
initial call: supervisor:cowboy_acceptors_sup/1
pid: 
registered_name: []
exception exit: {function_clause,
[{inet_tcp,getserv,
[{ok,20829}],
[{file,"inet_tcp.erl"},{line,35}]},
{gen_tcp,listen,2,[{file,"gen_tcp.erl"},{line,182}]},
{cowboy_acceptors_sup,init,1,
[{file,"src/cowboy_acceptors_sup.erl"},
{line,42}]},
{supervisor,init,1,
[{file,"supervisor.erl"},{line,233}]},
{gen_server,init_it,6,
[{file,"gen_server.erl"},{line,304}]},
{proc_lib,init_p_do_apply,3,
[{file,"proc_lib.erl"},{line,227}]}]}
in function gen_server:init_it/6 (gen_server.erl, line 328)
ancestors: [,cowboy_sup,]
messages: []
links: []
dictionary: []
trap_exit: true
status: running
heap_size: 987
stack_size: 24
reductions: 171
neighbours:

Please consider this pull request.
Thank you for reading.
